### PR TITLE
remove pervasives dependency

### DIFF
--- a/lib/js/src/Json_decode.js
+++ b/lib/js/src/Json_decode.js
@@ -4,7 +4,6 @@ var List                    = require("bs-platform/lib/js/list.js");
 var $$Array                 = require("bs-platform/lib/js/array.js");
 var Curry                   = require("bs-platform/lib/js/curry.js");
 var Js_exn                  = require("bs-platform/lib/js/js_exn.js");
-var Pervasives              = require("bs-platform/lib/js/pervasives.js");
 var Caml_exceptions         = require("bs-platform/lib/js/caml_exceptions.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
@@ -104,7 +103,7 @@ function array(decode, json) {
         if (exn[0] === DecodeError) {
           throw [
                 DecodeError,
-                exn[1] + ("\n\tin array at index " + Pervasives.string_of_int(i))
+                exn[1] + ("\n\tin array at index " + ("" + (String(i) + "")))
               ];
         } else {
           throw exn;

--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -64,7 +64,7 @@ let array decode json =
         try
           decode (Array.unsafe_get source i)
         with
-          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin array at index " ^ string_of_int i)
+          DecodeError msg -> raise @@ DecodeError (msg ^ "\n\tin array at index " ^ {j|$i|j})
         in
       Array.unsafe_set target i value;
     done;


### PR DESCRIPTION
use `string interpolation` to remove `pervasives` dependency as discussed in #21 