### PR TITLE
Add a more helpful error message to `oneOf`

### DIFF
--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -188,12 +188,13 @@ let oneOf decoders json =
   let rec inner decoders errors =
     match decoders with
     | [] ->
+        let revErrors = List.rev errors in
         raise @@ DecodeError
-              ({j|All decoders given to oneOf failed. Here are all the errors: $errors. And the JSON being decoded: |j} ^ _stringify json)
+              ({j|All decoders given to oneOf failed. Here are all the errors: $revErrors. And the JSON being decoded: |j} ^ _stringify json)
     | decode::rest ->
         try decode json with
         | DecodeError e ->
-             inner rest (List.append errors [e]) in
+             inner rest (e :: errors) in
   inner decoders []
 
 let either a b =


### PR DESCRIPTION
This changes the `oneOf` error message to be much more descriptive of the actual issue when all given decoders fail, and includes the reasons each of them failed for better debugging. This comes at a performance cost, but it seems like a negligible cost for a significant benefit in the most common cases.