### PR TITLE
Implement decoder/encoder for char type

### DIFF
--- a/__tests__/Json_decode_test.bs.js
+++ b/__tests__/Json_decode_test.bs.js
@@ -25,6 +25,8 @@ function valueFor(param) {
         return Json_encode.object_(/* [] */0);
     case 6 : 
         return true;
+    case 7 : 
+        return Json_encode.$$char(/* "a" */97);
     
   }
 }
@@ -60,7 +62,10 @@ describe("boolean", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -88,7 +93,10 @@ describe("bool", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -114,7 +122,10 @@ describe("float", (function () {
                           /* Array */4,
                           /* :: */[
                             /* Object */5,
-                            /* [] */0
+                            /* :: */[
+                              /* Char */7,
+                              /* [] */0
+                            ]
                           ]
                         ]
                       ]
@@ -149,7 +160,10 @@ describe("int", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -161,6 +175,9 @@ describe("int", (function () {
 describe("string", (function () {
         Jest.test("string", (function () {
                 return Jest.Expect[/* toEqual */12]("test", Jest.Expect[/* expect */0](Json_decode.string("test")));
+              }));
+        Jest.test("single-character string", (function () {
+                return Jest.Expect[/* toEqual */12]("a", Jest.Expect[/* expect */0](Json_decode.string(Json_encode.$$char(/* "a" */97))));
               }));
         return throws(/* None */0, Json_decode.string, /* :: */[
                     /* Bool */6,
@@ -188,6 +205,46 @@ describe("date", (function () {
                 return Jest.Expect[/* toEqual */12](new Date("2012-04-23T18:25:43.511Z"), Jest.Expect[/* expect */0](Json_decode.date("2012-04-23T18:25:43.511Z")));
               }));
         return throws(/* None */0, Json_decode.date, /* :: */[
+                    /* Bool */6,
+                    /* :: */[
+                      /* Float */0,
+                      /* :: */[
+                        /* Int */1,
+                        /* :: */[
+                          /* Null */3,
+                          /* :: */[
+                            /* Array */4,
+                            /* :: */[
+                              /* Object */5,
+                              /* [] */0
+                            ]
+                          ]
+                        ]
+                      ]
+                    ]
+                  ]);
+      }));
+
+describe("char", (function () {
+        Jest.test("character", (function () {
+                return Jest.Expect[/* toEqual */12](/* "a" */97, Jest.Expect[/* expect */0](Json_decode.$$char(Json_encode.$$char(/* "a" */97))));
+              }));
+        Jest.test("single-character string", (function () {
+                return Jest.Expect[/* toEqual */12](/* "a" */97, Jest.Expect[/* expect */0](Json_decode.$$char("a")));
+              }));
+        Jest.test("empty string", (function () {
+                return Jest.Expect[/* toThrowException */20]([
+                            Json_decode.DecodeError,
+                            "Expected single-character string, got \"\""
+                          ], Jest.Expect[/* expectFn */1](Json_decode.$$char, ""));
+              }));
+        Jest.test("multiple-character string", (function () {
+                return Jest.Expect[/* toThrowException */20]([
+                            Json_decode.DecodeError,
+                            "Expected single-character string, got \"abc\""
+                          ], Jest.Expect[/* expectFn */1](Json_decode.$$char, "abc"));
+              }));
+        return throws(/* None */0, Json_decode.$$char, /* :: */[
                     /* Bool */6,
                     /* :: */[
                       /* Float */0,
@@ -242,7 +299,10 @@ describe("nullable", (function () {
                     /* Array */4,
                     /* :: */[
                       /* Object */5,
-                      /* [] */0
+                      /* :: */[
+                        /* Char */7,
+                        /* [] */0
+                      ]
                     ]
                   ]
                 ]
@@ -283,7 +343,10 @@ describe("nullAs", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -368,7 +431,10 @@ describe("array", (function () {
                             /* Null */3,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -481,7 +547,10 @@ describe("list", (function () {
                             /* Null */3,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -804,7 +873,10 @@ describe("dict", (function () {
                             /* Null */3,
                             /* :: */[
                               /* Array */4,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -874,7 +946,10 @@ describe("field", (function () {
                               /* Array */4,
                               /* :: */[
                                 /* Object */5,
-                                /* [] */0
+                                /* :: */[
+                                  /* Char */7,
+                                  /* [] */0
+                                ]
                               ]
                             ]
                           ]
@@ -970,7 +1045,10 @@ describe("at", (function () {
                               /* Array */4,
                               /* :: */[
                                 /* Object */5,
-                                /* [] */0
+                                /* :: */[
+                                  /* Char */7,
+                                  /* [] */0
+                                ]
                               ]
                             ]
                           ]
@@ -1129,7 +1207,10 @@ describe("oneOf", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -1163,7 +1244,10 @@ describe("either", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -1228,7 +1312,10 @@ describe("map", (function () {
                             /* Array */4,
                             /* :: */[
                               /* Object */5,
-                              /* [] */0
+                              /* :: */[
+                                /* Char */7,
+                                /* [] */0
+                              ]
                             ]
                           ]
                         ]
@@ -1269,7 +1356,10 @@ describe("andThen", (function () {
                       /* Array */4,
                       /* :: */[
                         /* Object */5,
-                        /* [] */0
+                        /* :: */[
+                          /* Char */7,
+                          /* [] */0
+                        ]
                       ]
                     ]
                   ]

--- a/__tests__/Json_encode_test.bs.js
+++ b/__tests__/Json_encode_test.bs.js
@@ -33,6 +33,10 @@ Jest.test("date", (function () {
         return Jest.Expect[/* toEqual */12]("2012-04-23T18:25:43.511Z", Jest.Expect[/* expect */0](Json_encode.date(new Date("2012-04-23T18:25:43.511Z"))));
       }));
 
+Jest.test("char", (function () {
+        return Jest.Expect[/* toEqual */12]("a", Jest.Expect[/* expect */0](Json_encode.$$char(/* "a" */97)));
+      }));
+
 Jest.test("dict - empty", (function () {
         return Jest.Expect[/* toEqual */12]({ }, Jest.Expect[/* expect */0]({ }));
       }));

--- a/__tests__/Json_encode_test.ml
+++ b/__tests__/Json_encode_test.ml
@@ -40,6 +40,11 @@ test "date" (fun () ->
     date (Js.Date.fromString "2012-04-23T18:25:43.511Z")
     |> toEqual @@ Obj.magic "2012-04-23T18:25:43.511Z");
 
+test "char" (fun () ->
+  expect @@
+    char 'a'
+    |> toEqual @@ Obj.magic "a");
+
 test "dict - empty" (fun () ->
   expect @@
     dict @@ Js.Dict.empty ()

--- a/src/Json_decode.bs.js
+++ b/src/Json_decode.bs.js
@@ -5,6 +5,7 @@ var $$Array = require("bs-platform/lib/js/array.js");
 var Curry = require("bs-platform/lib/js/curry.js");
 var Js_exn = require("bs-platform/lib/js/js_exn.js");
 var Pervasives = require("bs-platform/lib/js/pervasives.js");
+var Caml_string = require("bs-platform/lib/js/caml_string.js");
 var Caml_exceptions = require("bs-platform/lib/js/caml_exceptions.js");
 var Caml_builtin_exceptions = require("bs-platform/lib/js/caml_builtin_exceptions.js");
 
@@ -63,6 +64,18 @@ function string(json) {
     throw [
           DecodeError,
           "Expected string, got " + JSON.stringify(json)
+        ];
+  }
+}
+
+function $$char(json) {
+  var s = string(json);
+  if (s.length === 1) {
+    return Caml_string.get(s, 0);
+  } else {
+    throw [
+          DecodeError,
+          "Expected single-character string, got " + JSON.stringify(json)
         ];
   }
 }
@@ -412,6 +425,7 @@ exports.bool = bool;
 exports.$$float = $$float;
 exports.$$int = $$int;
 exports.string = string;
+exports.$$char = $$char;
 exports.date = date;
 exports.nullable = nullable;
 exports.nullAs = nullAs;

--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -37,6 +37,13 @@ let string json =
   else
     raise @@ DecodeError ("Expected string, got " ^ _stringify json)
 
+let char json =
+  let s = string json in
+  if String.length s = 1 then
+    String.get s 0
+  else
+    raise @@ DecodeError ("Expected single-character string, got " ^ _stringify json)
+
 let date json =
   json |> string
        |> Js.Date.fromString

--- a/src/Json_decode.mli
+++ b/src/Json_decode.mli
@@ -113,6 +113,24 @@ val string : string decoder
 ]}
 *)
 
+val char : char decoder
+(** Decodes a JSON value into a [char]
+
+{b Returns} a [char] if the JSON value is a single-character string.
+
+@raise [DecodeError] if unsuccessful.
+
+@example {[
+  open Json
+  (* returns 'a' *)
+  let _ = Json.parseOrRaise "\"a\"" |> Decode.char
+  (* raises DecodeError *)
+  let _ = Json.parseOrRaise "\"abc\"" |> Decode.char
+  (* raises DecodeError *)
+  let _ = Json.parseOrRaise "null" |> Decode.char
+]}
+*)
+
 val date : Js.Date.t decoder
 (** Decodes an ISO8601-fot\rmatted JSON string into a [Js.Date.t]
     

--- a/src/Json_encode.bs.js
+++ b/src/Json_encode.bs.js
@@ -3,10 +3,15 @@
 var List = require("bs-platform/lib/js/list.js");
 var $$Array = require("bs-platform/lib/js/array.js");
 var Curry = require("bs-platform/lib/js/curry.js");
+var $$String = require("bs-platform/lib/js/string.js");
 var Js_dict = require("bs-platform/lib/js/js_dict.js");
 var Js_boolean = require("bs-platform/lib/js/js_boolean.js");
 
 var bool = Js_boolean.to_js_boolean;
+
+function $$char(c) {
+  return $$String.make(1, c);
+}
 
 function date(d) {
   return d.toJSON();
@@ -65,6 +70,7 @@ var tuple2 = pair;
 var arrayOf = array;
 
 exports.bool = bool;
+exports.$$char = $$char;
 exports.date = date;
 exports.nullable = nullable;
 exports.withDefault = withDefault;

--- a/src/Json_encode.ml
+++ b/src/Json_encode.ml
@@ -11,6 +11,10 @@ let bool b =
   b |> Js.Boolean.to_js_boolean
     |> boolean 
 
+let char c =
+  c |> String.make 1
+    |> string
+
 let date d =
   d |> Js.Date.toJSON
     |> string

--- a/src/Json_encode.mli
+++ b/src/Json_encode.mli
@@ -21,6 +21,9 @@ external boolean : Js.boolean -> Js.Json.t = "%identity"
 val bool : bool -> Js.Json.t
 (** [bool b] makes a JSON boolean of the [bool] [b] *)
 
+val char : char -> Js.Json.t
+(** [char c] makes a JSON string of the [char] [c] *)
+
 val date : Js.Date.t -> Js.Json.t
 (** [bool b] makes an ISO 8601 JSON string of the [Js.Date.t] [b] *)
 


### PR DESCRIPTION
This PR simply implements missing `char` decoder / encoder pair:

```ocaml
Json.Decode.char : Js.Json.t -> char
Json.Encode.char : char -> Js.Json.t
```

This is my first Pull Request in OCaml (after a bit of exposure to ReasonML) so any feedback is appreciated :)
Also thanks for maintaining this library, it has allowed me to greatly simplify my code, so I decided to give back :)