### PR TITLE
add dictOf encoder

### DIFF
--- a/__tests__/Json_encode_test.ml
+++ b/__tests__/Json_encode_test.ml
@@ -53,6 +53,14 @@ test "dict - simple" (fun () ->
     dict o
     |> toEqual @@ Obj.magic o);
 
+test "dictOf - simple" (fun () ->
+  let o = Js.Dict.empty () in
+  Js.Dict.set o "x" 42;
+
+  expect @@
+    dictOf int o
+    |> toEqual @@ Obj.magic o);
+
 test "object_ - empty" (fun () ->
   expect @@
     object_ @@ []
@@ -80,7 +88,7 @@ test "jsonArray int" (fun () ->
 
 test "stringArray" (fun () ->
   expect @@
-    stringArray [|"a";"b"|] 
+    stringArray [|"a";"b"|]
     |> toEqual @@ Obj.magic [|"a";"b"|]);
 
 test "numberArray" (fun () ->
@@ -93,13 +101,13 @@ test "boolArray" (fun () ->
     boolArray [|true;false|]
     |> toEqual @@ Obj.magic [|true;false|]);
 
-test "nullable (None)" (fun () -> 
+test "nullable (None)" (fun () ->
   expect @@
     nullable string None
     |> toEqual @@ null
 );
 
-test "nullable (Some)" (fun () -> 
+test "nullable (Some)" (fun () ->
   expect @@
     nullable string (Some "success")
     |> toEqual @@ string "success"
@@ -117,25 +125,25 @@ test "withDefault (Some)" (fun () ->
     |> toEqual @@ string "success"
 );
 
-test "pair" (fun () -> 
+test "pair" (fun () ->
   expect @@
     pair string float ("hello", 1.2)
     |> toEqual @@ jsonArray [|string "hello"; float 1.2|]
 );
 
-test "tuple2" (fun () -> 
+test "tuple2" (fun () ->
   expect @@
     tuple2 string float ("hello", 1.2)
     |> toEqual @@ jsonArray [|string "hello"; float 1.2|]
 );
 
-test "tuple3" (fun () -> 
+test "tuple3" (fun () ->
   expect @@
     tuple3 string float int ("hello", 1.2, 4)
     |> toEqual @@ jsonArray [|string "hello"; float 1.2; int 4|]
 );
 
-test "tuple4" (fun () -> 
+test "tuple4" (fun () ->
   expect @@
     tuple4 string float int bool ("hello", 1.2, 4, true)
     |> toEqual @@ jsonArray [|string "hello"; float 1.2; int 4; bool true|]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "bsb -make-world -w",
     "coverage": "nyc report --temp-directory=coverage --reporter=text-lcov | coveralls",
     "test": "npm run build && jest --coverage && npm run coverage && npm run test:examples",
+    "test:nocoverage": "npm run build && jest && npm run test:examples",
     "test:examples": "npm run build && ./run_examples.sh",
     "watch:bsb": "bsb -make-world -w",
     "watch:jest": "jest --coverage --watchAll",

--- a/src/Json_encode.ml
+++ b/src/Json_encode.ml
@@ -5,7 +5,12 @@ external string : string -> Js.Json.t = "%identity"
 external float : float -> Js.Json.t = "%identity"
 external int : int -> Js.Json.t = "%identity"
 external dict : Js.Json.t Js_dict.t -> Js.Json.t = "%identity"
-external bool : bool -> Js.Json.t = "%identity" 
+external bool : bool -> Js.Json.t = "%identity"
+
+let dictOf encode d =
+  let pairs = Js.Dict.entries d in
+  let encodedPairs = Array.map (fun (k, v) -> (k, encode(v))) pairs in
+  dict (Js.Dict.fromArray encodedPairs)
 
 let char c =
   c |> String.make 1

--- a/src/Json_encode.mli
+++ b/src/Json_encode.mli
@@ -15,7 +15,7 @@ external float : float -> Js.Json.t = "%identity"
 external int : int -> Js.Json.t = "%identity"
 (** [int n] makes a JSON number of the [int] [n] *)
 
-external bool : bool -> Js.Json.t = "%identity" 
+external bool : bool -> Js.Json.t = "%identity"
 (** [bool b] makes a JSON boolean of the [bool] [b] *)
 
 val char : char -> Js.Json.t
@@ -45,18 +45,21 @@ val tuple4 : 'a encoder -> 'b encoder -> 'c encoder -> 'd encoder -> ('a * 'b * 
 external dict : Js.Json.t Js_dict.t -> Js.Json.t = "%identity"
 (** [dict d] makes a JSON object of the [Js.Dict.t] [d] *)
 
+val dictOf : 'a encoder -> 'a Js_dict.t encoder
+(** [dict(enc) d] makes a JSON object of the [Js.Dict.t] [d] with the given encoder *)
+
 val object_ : (string * Js.Json.t) list -> Js.Json.t
 (** [object_ props] makes a JSON object of the [props] list of properties *)
 
 val array : 'a encoder -> 'a array encoder
-(** [arrayOf encoder l] makes a JSON array of the [list] [l] using the given [encoder] 
+(** [arrayOf encoder l] makes a JSON array of the [list] [l] using the given [encoder]
  *  NOTE: This will be renamed `array` once the existing and deprecated `array` function
  *  has been removed.
  *)
 
 val arrayOf : 'a encoder -> 'a array encoder
 [@@deprecated "Use `array` instead"]
-(** [arrayOf encoder l] makes a JSON array of the [list] [l] using the given [encoder] 
+(** [arrayOf encoder l] makes a JSON array of the [list] [l] using the given [encoder]
  *  NOTE: This will be renamed `array` once the existing and deprecated `array` function
  *  has been removed.
  *  @deprecated Use [array] instead
@@ -65,15 +68,15 @@ val arrayOf : 'a encoder -> 'a array encoder
 val list : 'a encoder -> 'a list encoder
 (** [list encoder a] makes a JSON array of the [array] [a] using the given [encoder] *)
 
-(** The functions below are specialized for specific array type which 
+(** The functions below are specialized for specific array type which
     happened to be already JSON object in the BuckleScript runtime. Therefore
-    they are more efficient (constant time rather than linear conversion). *) 
+    they are more efficient (constant time rather than linear conversion). *)
 
 external jsonArray : Js.Json.t array -> Js.Json.t = "%identity"
 (** [jsonArray a] makes a JSON array of the [Js.Json.t array] [a] *)
 
 external stringArray : string array -> Js.Json.t = "%identity"
-(** [stringArray a] makes a JSON array of the [string array] [a] *) 
+(** [stringArray a] makes a JSON array of the [string array] [a] *)
 
 external numberArray : float array -> Js.Json.t = "%identity"
 (** [numberArray a] makes a JSON array of the [float array] [a] *)


### PR DESCRIPTION
*My text editor trimmed off a bunch of trailing whitespace -- I can go and remove those edits if needed*

This adds a `dictOf` encoder which can encode an arbitrary `Js.Dict` rather than only one already containing `Json.t`. I considered replacing the existing `dict` encoder but that would make this a breaking change. But I do think it would be preferable in some ways (for one thing it would make it consistent with the other polymorphic encoders, and also the decoder for a `Dict` is polymorphic)