### PR TITLE
add a prepublish script to package the .bs.js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test:examples": "npm run build && ./run_examples.sh",
     "watch:bsb": "bsb -make-world -w",
     "watch:jest": "jest --coverage --watchAll",
-    "watch:screen": "screen -c .screenrc"
+    "watch:screen": "screen -c .screenrc",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I was running into an issue where I wanted to use a package which depends on `bs-json` as a dependency in a JS-only app. Since that app doesn't have any awareness of reasonml, it doesn't make sense to add `bs-platform` and a `bsconfig.json` etc to the JS app, but without that, there are no `.bs.js` files in `node_modules/@glennsl/bs-json`. 

I *believe* that adding this `prepublish` script will solve this problem, but (a) it's difficult to know because I can't test it without pushing/installing a new version of `bs-json`, and (b) I'm not sure if there are reasons why this would be undesirable, or if there's a better way.