### PR TITLE
Print each element in errors list individually

### DIFF
--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -194,7 +194,7 @@ let oneOf decoders json =
   let rec inner decoders errors =
     match decoders with
     | [] ->
-        let revErrors = List.rev errors in
+        let revErrors = Js.Array.joinWith ", " (Array.of_list (List.rev errors)) in
         raise @@ DecodeError
               ({j|All decoders given to oneOf failed. Here are all the errors: $revErrors. And the JSON being decoded: |j} ^ _stringify json)
     | decode::rest ->

--- a/src/Json_decode.ml
+++ b/src/Json_decode.ml
@@ -194,9 +194,9 @@ let oneOf decoders json =
   let rec inner decoders errors =
     match decoders with
     | [] ->
-        let revErrors = Js.Array.joinWith ", " (Array.of_list (List.rev errors)) in
+        let formattedErrors = "\n- " ^ Js.Array.joinWith "\n- " (Array.of_list (List.rev errors)) in
         raise @@ DecodeError
-              ({j|All decoders given to oneOf failed. Here are all the errors: $revErrors. And the JSON being decoded: |j} ^ _stringify json)
+              ({j|All decoders given to oneOf failed. Here are all the errors: $formattedErrors\nAnd the JSON being decoded: |j} ^ _stringify json)
     | decode::rest ->
         try decode json with
         | DecodeError e ->


### PR DESCRIPTION
Originally (pre bs-platform v8), error messages were:

```
All decoders given to oneOf failed. Here are all the errors: Expected string, got {},Expected array, got {},0. And the JSON being decoded: {}
```

After changes in list representation, the error messages are now:

```
All decoders given to oneOf failed. Here are all the errors: [object Object]. And the JSON being decoded: {}
```

This change fixes them to be:
```
All decoders given to oneOf failed. Here are all the errors: Expected string, got {}, Expected array, got {}. And the JSON being decoded: {}
```